### PR TITLE
Add Google Analytics tracking to layout

### DIFF
--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -27,6 +27,14 @@ const {
       href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600&family=Sora:wght@300;400;500;600&display=swap"
       rel="stylesheet"
     />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXXXXX');
+    </script>
     <style>
       * { box-sizing: border-box; }
       html { color-scheme: dark; }


### PR DESCRIPTION
## Summary
This PR adds Google Analytics (GA4) tracking to the main layout component, enabling analytics collection across the site.

## Changes
- Added Google Tag Manager (gtag.js) script to the layout head
- Initialized Google Analytics with configuration for tracking ID `G-XXXXXXXXXX`
- Set up the dataLayer object for event tracking

## Implementation Details
- The gtag.js script is loaded asynchronously to avoid blocking page rendering
- The tracking configuration is initialized immediately after the script loads
- The tracking ID is currently a placeholder (`G-XXXXXXXXXX`) and should be replaced with the actual GA4 measurement ID before deployment

**Note:** The tracking ID should be updated to the actual Google Analytics measurement ID before this change is merged to production.

https://claude.ai/code/session_013q7Ea6wE96g1pHS8F43JjN